### PR TITLE
fix: remove duplicate stylelint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "fix:esformat": "prettier --write 'src/**/*.js' 'src/**/*.ts'",
     "fix:eslint": "eslint --fix 'src/**/*.js' 'src/**/*.ts'",
-    "fix:stylelint": "stylelint stylelint --formatter verbose --fix 'src/**/*.scss'",
+    "fix:stylelint": "stylelint --formatter verbose --fix 'src/**/*.scss'",
     "fix": "npm-run-all --sequential fix:*",
     "start": "gulp",
     "browserslist-update-db": "npx browserslist@latest --update-db",


### PR DESCRIPTION
## Summary
- remove duplicate "stylelint" call from npm scripts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841378b7db8832192f2dbbf9af2552b