### PR TITLE
Update Node to 20 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 20.18.0
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- update Node setup in GitHub Actions CI workflow to version 20

## Testing
- `npm test` *(fails: ERR_REQUIRE_ASYNC_MODULE errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841385ca8f883218a5c44a2e8becd07