### PR TITLE
Add zeroPadding error handling and tests

### DIFF
--- a/src/assets/js/_string_utils.ts
+++ b/src/assets/js/_string_utils.ts
@@ -1,4 +1,8 @@
 export function zeroPadding(num: number, qty: number): string {
+  if (!Number.isInteger(num) || num < 0) {
+    throw new Error("num must be a positive integer");
+  }
+
   const numString = `${num}`;
   if (qty < numString.length) {
     console.warn("num is too large");

--- a/test/_string_utils.test.ts
+++ b/test/_string_utils.test.ts
@@ -23,4 +23,10 @@ describe('zeroPadding', () => {
     expect(zeroPadding(123, 2)).toBe("123");
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
+  test('zeroPadding(-1,2) throws', () => {
+    expect(() => zeroPadding(-1, 2)).toThrow();
+  });
+  test('zeroPadding(1.5,2) throws', () => {
+    expect(() => zeroPadding(1.5, 2)).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- validate non-integer or negative input in `zeroPadding`
- test error cases for negative numbers and decimals

## Testing
- `npm run fix`
- `npm test` *(fails: Exceeded timeout of 5000 ms for a hook)*

------
https://chatgpt.com/codex/tasks/task_e_6841405bb7108321bccc160564ba3608