### PR TITLE
Move cacheQuery definition next to version variable

### DIFF
--- a/src/_base.pug
+++ b/src/_base.pug
@@ -9,6 +9,8 @@ html(lang="ja")
     - var ogpUrl=""
     - var siteName=""
     - var mediaQueryPc="(min-width:768px)"
+    - var versionForCache=""
+    - var cacheQuery = versionForCache ? `?ver=${versionForCache}` : ""
   block functions
     -
       function zeroPadding(num, qty) {
@@ -72,10 +74,10 @@ html(lang="ja")
       link(rel="shortcut icon" href=faviconUrl)
 
     block styles
-      link(rel="stylesheet" href=relRoot+"assets/css/style.css")
+      link(rel="stylesheet" href=relRoot+"assets/css/style.css"+cacheQuery)
     block scripts
-      script(src=relRoot+"assets/js/bundle.js")
-      script(src=relRoot+"assets/js/common.js")
+      script(src=relRoot+"assets/js/bundle.js"+cacheQuery)
+      script(src=relRoot+"assets/js/common.js"+cacheQuery)
   body
     .l-wrapper
       .l-header

--- a/src/index.pug
+++ b/src/index.pug
@@ -5,7 +5,7 @@ block append vars
   - ogpImage="https://dummyimage.com/1200x600/00ff00/0011ff.jpg"
 block append styles
 block append scripts
-  script(src=relRoot+"assets/js/index.js")
+  script(src=relRoot+"assets/js/index.js"+cacheQuery)
 block main
   .p-dummy-background-images
     .p-dummy-background-images__image.p-dummy-background-images__image--image01 イメージ01


### PR DESCRIPTION
## Summary
- relocate `cacheQuery` declaration right after `versionForCache`
- rely on the global `cacheQuery` variable from index page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68466f1c7c2883219e26178bc8abcb9a